### PR TITLE
FLOE-497: Upgrades to Flocking dev release, fixes broken demo URLs and adds Testem support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 src/lib/
 tests/lib
+report.tap

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,8 +33,10 @@ module.exports = function (grunt) {
                     {expand: true, cwd: "./node_modules/d3/", src: "**", dest: "./src/lib/d3/"},
                     // Flocking
                     {expand: true, cwd: "./node_modules/flocking/", src: "**", dest: "./src/lib/flocking/"},
-                    // Infusion
-                    {expand: true, cwd: "./node_modules/infusion/dist", src: "**", dest: "./src/lib/infusion"},
+                    // Infusion distribution files
+                    {expand: true, cwd: "./node_modules/infusion/dist", src: "**", dest: "./src/lib/infusion/dist"},
+                    // Infusion source
+                    {expand: true, cwd: "./node_modules/infusion/src", src: "**", dest: "./src/lib/infusion/src"},
                     // Infusion testing framework
                     {expand: true, cwd: "./node_modules/infusion/tests", src: "**", dest: "./tests/lib/infusion"}
                 ]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,20 +34,10 @@ module.exports = function (grunt) {
                     // Flocking
                     {expand: true, cwd: "./node_modules/flocking/", src: "**", dest: "./src/lib/flocking/"},
                     // Infusion
-                    {expand: true, cwd: "./node_modules/infusion/build", src: "**", dest: "./src/lib/infusion"},
+                    {expand: true, cwd: "./node_modules/infusion/dist", src: "**", dest: "./src/lib/infusion"},
                     // Infusion testing framework
-                    {expand: true, cwd: "./node_modules/infusion/build/tests", src: "**", dest: "./tests/lib/infusion"}
+                    {expand: true, cwd: "./node_modules/infusion/tests", src: "**", dest: "./tests/lib/infusion"}
                 ]
-            }
-        },
-        exec: {
-            infusionInstall: {
-                command: "npm install",
-                cwd: "./node_modules/infusion"
-            },
-            infusionBuild: {
-                command: "grunt build",
-                cwd: "./node_modules/infusion"
             }
         }
     });
@@ -62,5 +52,5 @@ module.exports = function (grunt) {
 
     grunt.registerTask("default", ["lint"]);
     grunt.registerTask("lint", "Apply eslint and jsonlint", ["eslint", "jsonlint"]);
-    grunt.registerTask("installFrontEnd", "Install front-end dependencies from the node_modules directory after 'npm install'", ["exec:infusionInstall", "exec:infusionBuild", "copy:frontEndDependencies"]);
+    grunt.registerTask("installFrontEnd", "Install front-end dependencies from the node_modules directory after 'npm install'", ["copy:frontEndDependencies"]);
 };

--- a/demos/index.html
+++ b/demos/index.html
@@ -3,20 +3,20 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" href="../src/lib/infusion/src/lib/normalize/css/normalize.css" />
-        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/framework/core/css/fluid.css" />
-        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
-        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/components/inlineEdit/css/InlineEdit.css" />
+        <link rel="stylesheet" href="../node_modules/infusion/src/lib/normalize/css/normalize.css" />
+        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/framework/core/css/fluid.css" />
+        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
+        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/components/inlineEdit/css/InlineEdit.css" />
 
-        <script src="../src/lib/infusion/infusion-all.js"></script>
-        <script src="../src/lib/d3/d3.js"></script>
+        <script src="../node_modules/infusion/dist/infusion-all.js"></script>
+        <script src="../node_modules/d3/d3.js"></script>
 
-        <script src="../src/lib/flocking/dist/flocking-base.js"></script>
-        <script src="../src/lib/flocking/src/ugens/oscillators.js"></script>
-        <script src="../src/lib/flocking/src/ugens/math.js"></script>
-        <script src="../src/lib/flocking/src/ugens/envelopes.js"></script>
-        <script src="../src/lib/flocking/src/ugens/midi.js"></script>
-        <script src="../src/lib/flocking/src/ugens/scheduling.js"></script>
+        <script src="../node_modules/flocking/dist/flocking-base.js"></script>
+        <script src="../node_modules/flocking/src/ugens/oscillators.js"></script>
+        <script src="../node_modules/flocking/src/ugens/math.js"></script>
+        <script src="../node_modules/flocking/src/ugens/envelopes.js"></script>
+        <script src="../node_modules/flocking/src/ugens/midi.js"></script>
+        <script src="../node_modules/flocking/src/ugens/scheduling.js"></script>
 
         <script src="../src/js/flockInit.js"></script>
         <script src="../src/js/valueBinding.js"></script>

--- a/demos/index.html
+++ b/demos/index.html
@@ -3,20 +3,20 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <link rel="stylesheet" href="../node_modules/infusion/src/lib/normalize/css/normalize.css" />
-        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/framework/core/css/fluid.css" />
-        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
-        <link rel="stylesheet" type="text/css" href="../node_modules/infusion/src/components/inlineEdit/css/InlineEdit.css" />
+        <link rel="stylesheet" href="../src/lib/infusion/src/lib/normalize/css/normalize.css" />
+        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/framework/core/css/fluid.css" />
+        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/components/overviewPanel/css/OverviewPanel.css" />
+        <link rel="stylesheet" type="text/css" href="../src/lib/infusion/src/components/inlineEdit/css/InlineEdit.css" />
 
-        <script src="../node_modules/infusion/dist/infusion-all.js"></script>
-        <script src="../node_modules/d3/d3.js"></script>
+        <script src="../src/lib/infusion/infusion-all.js"></script>
+        <script src="../src/lib/d3/d3.js"></script>
 
-        <script src="../node_modules/flocking/dist/flocking-base.js"></script>
-        <script src="../node_modules/flocking/src/ugens/oscillators.js"></script>
-        <script src="../node_modules/flocking/src/ugens/math.js"></script>
-        <script src="../node_modules/flocking/src/ugens/envelopes.js"></script>
-        <script src="../node_modules/flocking/src/ugens/midi.js"></script>
-        <script src="../node_modules/flocking/src/ugens/scheduling.js"></script>
+        <script src="../src/lib/flocking/dist/flocking-base.js"></script>
+        <script src="../src/lib/flocking/src/ugens/oscillators.js"></script>
+        <script src="../src/lib/flocking/src/ugens/math.js"></script>
+        <script src="../src/lib/flocking/src/ugens/envelopes.js"></script>
+        <script src="../src/lib/flocking/src/ugens/midi.js"></script>
+        <script src="../src/lib/flocking/src/ugens/scheduling.js"></script>
 
         <script src="../src/js/flockInit.js"></script>
         <script src="../src/js/valueBinding.js"></script>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "http://www.fluidproject.org/",
   "dependencies": {
     "d3": "3.5.17",
-    "flocking": "colinbdclark/Flocking#18e94e6fb7a51f0b37c8e69063eb00ff6d1badce",
+    "flocking": "colinbdclark/Flocking#5644a8a93df8461ec2596679f51754512f185f8e",
     "infusion": "2.0.0"
   },
   "license": "(BSD-3-Clause OR ECL-2.0)",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "http://www.fluidproject.org/",
   "dependencies": {
     "d3": "3.5.17",
-    "flocking": "colinbdclark/Flocking#5644a8a93df8461ec2596679f51754512f185f8e",
+    "flocking": "0.2.0-dev.20170206T221943Z.fb09a52",
     "infusion": "2.0.0"
   },
   "license": "(BSD-3-Clause OR ECL-2.0)",
@@ -33,6 +33,7 @@
     "grunt-jsonlint": "1.1.0"
   },
   "scripts": {
-    "postinstall": "grunt installFrontEnd"
+    "postinstall": "grunt installFrontEnd",
+    "test": "testem ci --file tests/testem.json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "homepage": "http://www.fluidproject.org/",
   "dependencies": {
     "d3": "3.5.17",
-    "flocking": "colinbdclark/Flocking#6749bee2b7041b76f494bd188b755d568332eda0",
-    "infusion": "2.0.0-dev.20160902T155354Z.b963420"
+    "flocking": "colinbdclark/Flocking#18e94e6fb7a51f0b37c8e69063eb00ff6d1badce",
+    "infusion": "2.0.0"
   },
   "license": "(BSD-3-Clause OR ECL-2.0)",
   "keywords": [

--- a/src/js/pie.js
+++ b/src/js/pie.js
@@ -68,7 +68,7 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             // boolean to configure drawing a background circle for the pie
             displayPieBackground: true,
             // color of the background circle, if drawn
-            pieBackgroundColor: "#F2F2F2"
+            pieBackgroundColor: "#f2f2f2"
         },
         styles: {
             svg: "floe-ca-pieChart-pie",

--- a/tests/all-tests.html
+++ b/tests/all-tests.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="lib/infusion/lib/qunit/addons/composite/qunit-composite.css">
     <script src="lib/infusion/lib/qunit/js/qunit.js"></script>
     <script src="lib/infusion/lib/qunit/addons/composite/qunit-composite.js"></script>
+    <script src="/testem.js"></script>
 
     <script>
     QUnit.testSuites("The Chart Authoring Tool Tests", [

--- a/tests/html/chartAuthoring-Tests.html
+++ b/tests/html/chartAuthoring-Tests.html
@@ -22,6 +22,7 @@
         <script src="../lib/infusion/test-core/jqUnit/js/jqUnit-browser.js"></script>
         <script src="../lib/infusion/test-core/utils/js/IoCTestUtils.js"></script>
 
+        <script src="../../src/js/flockInit.js"></script>
         <script src="../../src/js/templateInjection.js"></script>
         <script src="../../src/js/valueBinding.js"></script>
         <script src="../../src/js/percentage.js"></script>

--- a/tests/testem.json
+++ b/tests/testem.json
@@ -1,0 +1,7 @@
+{
+    "test_page": "tests/all-tests.html",
+    "timeout": 300,
+    "skip": "IE",
+    "reporter": "tap",
+    "report_file": "report.tap"
+}


### PR DESCRIPTION
This PR includes @waharnum's #17. It adds the following extra changes:

1. Upgrades to the latest (first ever) Flocking 0.2.0 npm dev release
2. Somewhat kludgily fixes the broken demo styling by copying all of Infusion's source as part of the copy.frontEndDependencies Grunt step
3. Adds support for Testem, because running web unit tests without Testem is sad.

@waharnum, you should cast an eye over this and see if it suits your standards. @amb26 or @cindyli since this includes code from both me and @waharnum, it might be best if one of you reviewed and merged it?