### PR TITLE
GPII-2358: configurable transitions for line charts, removal of postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-##What Is the Chart Authoring Tool?##
+## What Is the Chart Authoring Tool?##
 
 A tool for authoring accessible charts for the web. Including a sonified (audio) version of the chart.
 
-##How Do I Get the Chart Authoring Tool?##
+## How Do I Get the Chart Authoring Tool?##
 
 You can checkout and fork the Chart Authoring Tool on github:
 
 <https://github.com/fluid-project/chartAuthoring>
 
-##Who Makes the Chart Authoring Tool, and How Can I Help?##
+## Who Makes the Chart Authoring Tool, and How Can I Help?##
 
 The Fluid community is an international group of designers, developers, and testers who focus on a common mission: improving the user experience and accessibility of the open web.
 
 The best way to join the Fluid Community is to jump into any of our community activities. Visit our [website](http://fluidproject.org/) for links to our mailing lists, chat room, wiki, etc.
 
-##Building
+## Building the Demos and Running the Tests
 
 Requirements:
 * `npm`
 
 Steps:
 * `npm install`
-    * postinstall should run the `grunt installFrontEnd` task after installation completes
+* Run the `grunt installFrontEnd` task after installation completes
 
 Result:
-* The root directory can now serve up the demos and tests as a static site
+* Access `demos` and `tests` from the root directory to run the demos and tests
 
-##Testing
+## Testing
 
 If you have `testem` installed ([details here for installing testem](https://github.com/testem/testem/#installation)), you can run the unit tests with `npm test`.

--- a/package.json
+++ b/package.json
@@ -31,8 +31,5 @@
     "grunt-contrib-copy": "1.0.0",
     "grunt-exec": "1.0.0",
     "grunt-jsonlint": "1.1.0"
-  },
-  "scripts": {
-    "postinstall": "grunt installFrontEnd"
   }
 }

--- a/src/js/lineChartTimeSeriesArea.js
+++ b/src/js/lineChartTimeSeriesArea.js
@@ -63,6 +63,9 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             removeArea: {
                 funcName: "floe.chartAuthoring.lineChart.timeSeries.area.removeArea",
                 args: ["{that}"]
+            },
+            transitionArea: {
+                funcName: "floe.chartAuthoring.lineChart.timeSeries.area.updateArea.paginateTransition"
             }
         }
     });
@@ -113,7 +116,11 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             ),
             width = that.options.svgOptions.width;
 
-        that.chartLineAreaPaths
+        that.transitionArea(that.chartLineAreaPaths, area, width, transitionLength);
+    };
+
+    floe.chartAuthoring.lineChart.timeSeries.area.updateArea.paginateTransition = function (chartLineAreaPaths, area, width, transitionLength) {
+        chartLineAreaPaths
         .transition()
         .duration(transitionLength / 2)
         .attr({
@@ -132,7 +139,6 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
                 "transform": "translate(0)"
             });
         });
-
     };
 
     floe.chartAuthoring.lineChart.timeSeries.area.removeArea = function (that) {

--- a/src/js/lineChartTimeSeriesArea.js
+++ b/src/js/lineChartTimeSeriesArea.js
@@ -119,6 +119,7 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
         that.transitionArea(that.chartLineAreaPaths, area, width, transitionLength);
     };
 
+    // Transitions a chart line in a left-sliding "page browse" style
     floe.chartAuthoring.lineChart.timeSeries.area.updateArea.paginateTransition = function (chartLineAreaPaths, area, width, transitionLength) {
         chartLineAreaPaths
         .transition()
@@ -137,6 +138,22 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             .transition()
             .attr({
                 "transform": "translate(0)"
+            });
+        });
+    };
+
+    // Uses D3's default transition; this results in the
+    // "wriggle" described at https://bost.ocks.org/mike/path/
+    floe.chartAuthoring.lineChart.timeSeries.area.updateArea.defaultTransition = function (chartLineAreaPaths, area, width, transitionLength) {
+        chartLineAreaPaths
+        .each(function () {
+            d3.select(this)
+            .transition()
+            .duration(transitionLength)
+            .attr({
+                "d": function (d) {
+                    return area(d.data);
+                }
             });
         });
     };

--- a/src/js/lineChartTimeSeriesLine.js
+++ b/src/js/lineChartTimeSeriesLine.js
@@ -71,6 +71,9 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             removeChartLine: {
                 funcName: "floe.chartAuthoring.lineChart.timeSeries.line.removeChartLine",
                 args: ["{that}"]
+            },
+            transitionChartLine: {
+                funcName: "floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.paginateTransition"
             }
         }
     });
@@ -118,11 +121,20 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
     };
 
     floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine = function (that) {
+
         var line = floe.chartAuthoring.lineChart.timeSeries.line.getLineGenerator(that),
             transitionLength = that.options.lineOptions.transitionLength,
             width = that.options.svgOptions.width;
 
-        that.chartLinePaths
+        var chartLinePaths = that.chartLinePaths;
+
+        that.transitionChartLine(chartLinePaths, line, transitionLength, width);
+    };
+
+
+    // Transitions a chart line in a left-sliding "page browse" style
+    floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.paginateTransition = function (chartLinePaths, line, transitionLength, width) {
+        chartLinePaths
         .transition()
         .duration(transitionLength / 2)
         .attr({

--- a/src/js/lineChartTimeSeriesLine.js
+++ b/src/js/lineChartTimeSeriesLine.js
@@ -126,14 +126,12 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             transitionLength = that.options.lineOptions.transitionLength,
             width = that.options.svgOptions.width;
 
-        var chartLinePaths = that.chartLinePaths;
-
-        that.transitionChartLine(chartLinePaths, line, transitionLength, width);
+        that.transitionChartLine(that.chartLinePaths, line, width, transitionLength);
     };
 
 
     // Transitions a chart line in a left-sliding "page browse" style
-    floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.paginateTransition = function (chartLinePaths, line, transitionLength, width) {
+    floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.paginateTransition = function (chartLinePaths, line, width, transitionLength) {
         chartLinePaths
         .transition()
         .duration(transitionLength / 2)

--- a/src/js/lineChartTimeSeriesLine.js
+++ b/src/js/lineChartTimeSeriesLine.js
@@ -153,6 +153,22 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
         });
     };
 
+    // Uses D3's default transition; this results in the
+    // "wriggle" described at https://bost.ocks.org/mike/path/
+    floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.defaultTransition = function (chartLinePaths, line, width, transitionLength) {
+        chartLinePaths
+        .each(function () {
+            d3.select(this)
+            .transition()
+            .duration(transitionLength)
+            .attr({
+                "d": function (d) {
+                    return line(d.data);
+                }
+            });
+        });
+    };
+
     floe.chartAuthoring.lineChart.timeSeries.line.removeChartLine = function (that) {
         // Remove any removed lines
         var removedPaths = that.chartLinePaths.exit();

--- a/src/js/lineChartTimeSeriesPoints.js
+++ b/src/js/lineChartTimeSeriesPoints.js
@@ -77,6 +77,9 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             updatePoints: {
                 funcName: "floe.chartAuthoring.lineChart.timeSeries.points.updatePoints",
                 args: ["{that}"]
+            },
+            transitionPoints: {
+                funcName: "floe.chartAuthoring.lineChart.timeSeries.points.updatePoints.paginateTransition"
             }
         }
     });
@@ -158,8 +161,13 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             yScale = that.getYScale(),
             xScale = that.getXScale(),
             width = that.options.svgOptions.width;
-            // Transition circles
-        that.chartLinePointGroups.each(function () {
+
+        that.transitionPoints(that.chartLinePointGroups, yScale, xScale, width, transitionLength);
+    };
+
+    floe.chartAuthoring.lineChart.timeSeries.points.updatePoints.paginateTransition = function (chartLinePointGroups, yScale, xScale, width, transitionLength) {
+        // Transition circles
+        chartLinePointGroups.each(function () {
             var currentGroup = d3.select(this);
 
             currentGroup.selectAll("circle")
@@ -184,9 +192,7 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
                     "transform": "translate(0)"
                 });
             });
-
-
         });
-
     };
+
 })(jQuery, fluid);

--- a/src/js/lineChartTimeSeriesPoints.js
+++ b/src/js/lineChartTimeSeriesPoints.js
@@ -195,4 +195,26 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
         });
     };
 
+    floe.chartAuthoring.lineChart.timeSeries.points.updatePoints.defaultTransition = function (chartLinePointGroups, yScale, xScale, width, transitionLength) {
+        // Transition circles
+        chartLinePointGroups.each(function () {
+            var currentGroup = d3.select(this);
+
+            currentGroup.selectAll("circle")
+            .each(function () {
+                d3.select(this)
+                .transition()
+                .duration(transitionLength)
+                .attr({
+                    "cy": function (d) {
+                        return yScale(d.value);
+                    },
+                    "cx": function (d) {
+                        return xScale(new Date(d.date));
+                    }
+                });
+            });
+        });
+    };
+
 })(jQuery, fluid);

--- a/src/js/xAxisTimeSeries.js
+++ b/src/js/xAxisTimeSeries.js
@@ -38,7 +38,7 @@ https://raw.githubusercontent.com/fluid-project/chartAuthoring/master/LICENSE.tx
             // with the exception that 'month' uses the 3-character
             // month name shorthand rather than the full name
             XAxisTimeSeriesTickFormats: {
-                milliseconds: "%.L",
+                milliseconds: ".%L",
                 seconds: ":%S",
                 minute: "%I:%M",
                 hour: "%I %p",


### PR DESCRIPTION
This PR contains two changes originating in the Nexus science lab visualization work:

1) Update transitions for the line chart elements (lines, areas and points) are now configurable through an invoker-based system. This allows end users to implement their own styles of transition which may be more suitable to different kinds of applications. This is described in more detail at https://issues.gpii.net/browse/GPII-2358

2) The `postinstall` script has been removed from `package.json`; as we use the chartAuthoring library as a dependency in more places, having the postinstall run continues to be an irritation that must be overcome by specialized instructions. Eventually, as described at https://issues.fluidproject.org/browse/FLOE-509, we will divide the chartAuthoring functionality into a number of separate libraries, and have a separate repo of demos that use the new "materialization toolkit" described in FLOE-509 to author multimodal charts.