### PR TITLE
FLUID-6288 Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+node_modules
+src/lib
+tests/lib
+report.tap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:4.9.1 AS builder
+
+RUN apt-get update && \
+    apt-get install -y libasound2-dev
+
+USER node
+COPY --chown=node . /home/node/app
+WORKDIR /home/node/app
+RUN npm install
+
+
+FROM nginx:1.18.0-alpine
+COPY --from=builder /home/node/app /usr/share/nginx/html


### PR DESCRIPTION
I tried to update the dependencies but there were a lot of errors.

So I've opted to use the Node.js version that worked with it. It's unsupported and far from ideal but it's what works today. In the future, if we can update the dependencies and fix the code, then we can update the Node.js.

I need this to start moving our workloads into containers.

When https://github.com/fluid-project/chartAuthoring/pull/20 gets merged, I can update the Dockerfile to use a more recent Node.js version.

**How to test**

$ git clone ...
$ docker build -t chartauthoring .
$ docker run --rm -ti -p 8000:80 chartautoring
$ open http://localhost:8000/demos